### PR TITLE
fix(redis): retry with exponential backoff on startup

### DIFF
--- a/pkg/utils/redis.go
+++ b/pkg/utils/redis.go
@@ -1,22 +1,52 @@
 package utils
 
 import (
+	"fmt"
+	"log/slog"
+	"math"
+	"time"
 	"github.com/redis/rueidis"
 )
 
 var rdb rueidis.Client
 
+const (
+	redisMaxRetries    = 10
+	redisBaseDelay     = 300 * time.Millisecond
+	redisBackoffFactor = 2.7
+	redisMaxDelay      = 15 * time.Second
+)
+
 func InitRedis() error {
 	opt, err := rueidis.ParseURL(GetEnv("redis.url"))
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid redis url: %w", err)
 	}
-	client, err := rueidis.NewClient(opt)
-	if err != nil {
-		return err
+
+	var lastErr error
+	for attempt := range redisMaxRetries {
+		var client rueidis.Client
+		client, lastErr = rueidis.NewClient(opt)
+		if lastErr == nil {
+			rdb = client
+			return nil
+		}
+		if attempt == redisMaxRetries-1 {
+			break
+		}
+		delay := time.Duration(math.Min(
+			float64(redisBaseDelay)*math.Pow(redisBackoffFactor, float64(attempt)),
+			float64(redisMaxDelay),
+		))
+		slog.Warn("redis connection failed, retrying",
+			"attempt", attempt+1,
+			"maxRetries", redisMaxRetries,
+			"retryIn", delay.String(),
+			"error", lastErr,
+		)
+		time.Sleep(delay)
 	}
-	rdb = client
-	return nil
+	return fmt.Errorf("redis connection failed after %d attempts: %w", redisMaxRetries, lastErr)
 }
 
 func GetRedisClient() rueidis.Client {


### PR DESCRIPTION
rueidis.NewClient pings Redis immediately; if the container starts before Redis is ready the backend fatals. Retry up to 10 times with exponential backoff (300ms → 810ms → 2.2s → … capped at 15s).

- **Root cause**: rueidis.NewClient calls Ping on init; if Redis isn't ready yet (race condition in Docker Compose / NixOS oci-containers start order) it fatals and the Go API dies while the Nuxt frontend keeps running, causing 500s on every page.
- **Why `pkg/utils` and not `main.go`**: the change lands in the shared module so both backend and worker benefit automatically.
- **No new dependencies**: log/slog is stdlib since Go 1.21.